### PR TITLE
mention bulkEditing option in changeEditorInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,8 @@ Changes the editor interface of given field's ID.
 - **`falseLabel : string`** _(only for fields of type boolean)_ – Shows this text next to the radio button that sets this value to `false`. Defaults to “No”.
 - **`stars : number`** _(only for fields of type rating)_ – Number of stars to select from. Defaults to 5.
 - **`format : string`** _(only for fields of type datePicker)_ – One of “dateonly”, “time”, “timeZ” (default). Specifies whether to show the clock and/or timezone inputs.
-- **`ampm : string`** _(only for fields of type datePicker)_ – Specifies which type of clock to use. Must be one of the stringss “12” or “24” (default).
+- **`ampm : string`** _(only for fields of type datePicker)_ – Specifies which type of clock to use. Must be one of the strings “12” or “24” (default).
+- **`bulkEditing : boolean`** _(only for fields of type Array)_ – Specifies whether bulk editing of linked entries is possible.
 
 #### `resetEditorInterface (fieldId)` : void
 


### PR DESCRIPTION
<!--
Thank you for reporting an issue.

Please fill in as much of the template below as you're able. Feel free to delete
any section you want to skip.

PLEASE **DO NOT** share any credentials related to your Contentful account like
<space_id> or <access_token>. If this is an urgent issue you are having with Contentful
It's better to contact [support@contentful.com](mailto:support@contentful.com).
-->

## Summary

I didn't see `bulkEditing` mentioned in the docs for `changeEditorInterface` but I tried it using the CLI and it works. Here's the documentation.

## Description

It's a change to the README to mention a previously existing feature of the CLI.

## Motivation and Context

It's required to inform users of the API option.
